### PR TITLE
do not force torch onto unsuspecting victims

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Meila, Marina (2003). Comparing Clusterings by the Variation of Information. Lea
 
 ## Usage
 
-By default, pyvoi uses torch to compute the variation of information.
+By default, pyvoi will try to use torch, then numpy, to compute the variation of information.
 
 ### To get VI values only
     import pyvoi
@@ -59,7 +59,7 @@ By default, pyvoi uses torch to compute the variation of information.
     import pyvoi
     labels1=np.array([0,1,1,2,4])
     labels2=np.array([0,2,3,4,4])
-    vi,vi_split,vi_merge=pyvoi.VI(labels1,labels2,torch=False)
+    vi,vi_split,vi_merge=pyvoi.VI(labels1,labels2)
     print(vi,vi_split,vi_merge)
     #0.5545177444479561 0.27725887222397794 0.27725887222397816
     

--- a/setup.py
+++ b/setup.py
@@ -6,14 +6,14 @@ long_description = (this_directory / "README.md").read_text()
 
 setuptools.setup(
     name="python-voi",
-    version="0.0.2",
+    version="0.0.3",
     author="Core Francisco Park",
     author_email="cfpark00@gmail.com",
     description="Python implementation of Variation of Information",
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='MIT',
-    install_requires=["numpy","torch"],
+    install_requires=["numpy"],
     project_urls={
         "Source": "https://github.com/cfpark00/pyvoi.git"
     },


### PR DESCRIPTION
I did not need torch for my use-case.   
This removes the hard requirement for torch, because torch would've broken other libraries in my environment.

(force-push: commit squash & I forgot to set the commit author)